### PR TITLE
fix: remove invalid and needless ARIA roles

### DIFF
--- a/build
+++ b/build
@@ -23,7 +23,7 @@ do
   mv "$file" "${file/_24px/}"
 done
 
-npx @svgr/cli --index-template index-template.cjs --template component-template.cjs --typescript --no-svgo --svg-props role="graphics-symbol img" --svg-props focusable=false --svg-props aria-hidden=true --out-dir $react_tmp_path -- $original_svg_path
+npx @svgr/cli --index-template index-template.cjs --template component-template.cjs --typescript --no-svgo --svg-props focusable=false --svg-props aria-hidden=true --out-dir $react_tmp_path -- $original_svg_path
 
 ls $react_tmp_path > files.txt
 


### PR DESCRIPTION
The `graphics-symbol` role is not officially specified and not understood my assistive technologies.
Furthermore, the build script tests the `aria-hidden` attribute. Thereby the icons are not available in the accessibility tree anyway, so they don't need any role.

We received a hint for this in an external accessibility audit.